### PR TITLE
Update imports to make this repo no longer a fork in terms of import paths

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,3 +1,3 @@
 // Package throttled implements rate limiting access to resources such
 // as HTTP endpoints.
-package throttled // import "github.com/throttled/throttled"
+package throttled // import "github.com/bartekn/throttled"

--- a/http_test.go
+++ b/http_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/throttled/throttled"
+	"github.com/bartekn/throttled"
 )
 
 type stubLimiter struct {

--- a/rate_test.go
+++ b/rate_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/throttled/throttled"
+	"github.com/bartekn/throttled"
 )
 
 type clockFixed time.Time

--- a/varyby_test.go
+++ b/varyby_test.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/throttled/throttled"
+	"github.com/bartekn/throttled"
 )
 
 func TestVaryBy(t *testing.T) {


### PR DESCRIPTION
### Summary

Update imports to make this repo no longer a fork in terms of import paths. This repo will no longer be `github.com/throttled/throttled` available at a different URL, instead it will be `github.com/bartekn/throttled`.

### Goal and scope

This package is imported into the `stellar/go` repository as a fork of `github.com/throttled/throttled`. In recent versions of Go Modules there appears to be a bug (golang/go#33795) that cause packages that don't have a `go.mod` when `replace`d to not be importable. To make migrating to Go Modules (stellar/go#1634) easier it will be lower effort and less blocking to simply change this repository to standalone rather than be a fork. In principle since this fork has diverged significantly it's unlikely to be merged back upstream anyway.

### Summary of changes

- Rename the package path to `github.com/bartekn/throttled` in `doc.go`.
- Rename all self imports from test packages to `github.com/bartekn/throttled` in `_test.go` files.

